### PR TITLE
Add options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,11 @@
 #                 default value: true
 # version       - passed to puppet type 'package', attribute 'ensure'
 # add_repo      - if set to false (defaults to true), the yum/apt repo is not added
+# varnish_user  - user under which varnish daemon runs
+# varnish_group - group under which varnish daemon runs
+# extra_options - hash. generic options that can be passed on to the daemon via
+#                 the -p option. every key => value will result in a separate
+#                 -p key=value line
 #
 # === Default values
 # Set to Varnish default values
@@ -68,6 +73,7 @@ class varnish (
   $manage_firewall              = false,
   $varnish_user                 = 'varnish',
   $varnish_group                = 'varnish',
+  $extra_options                = {},
 ) {
 
   # read parameters

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,8 @@ class varnish (
   $default_version              = 3,
   $add_repo                     = true,
   $manage_firewall              = false,
+  $varnish_user                 = 'varnish',
+  $varnish_group                = 'varnish',
 ) {
 
   # read parameters

--- a/templates/varnish-conf.erb
+++ b/templates/varnish-conf.erb
@@ -96,4 +96,6 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -w ${VARNISH_MIN_THREADS},${VARNISH_MAX_THREADS},${VARNISH_THREAD_TIMEOUT}"
 <% end %>
 
-
+# set umask to 022 to prevent varnish from crashing at reload
+# see: http://lists.alioth.debian.org/pipermail/pkg-varnish-devel/2012-January/000358.html
+umask 022

--- a/templates/varnish-conf.erb
+++ b/templates/varnish-conf.erb
@@ -85,6 +85,9 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -s ${VARNISH_STORAGE} \
              -u ${VARNISH_USER} \
              -g ${VARNISH_GROUP} \
+<% scope.lookupvar('varnish::extra_options').each_pair do |key,value| -%>
+             -p <%= key %>=<%= value %> \
+<% end -%>
 <% if scope.lookupvar('varnish::params::version') == 4 -%>
              -p thread_pool_min=${VARNISH_MIN_THREADS} \
              -p thread_pool_max=${VARNISH_MAX_THREADS} \

--- a/templates/varnish-conf.erb
+++ b/templates/varnish-conf.erb
@@ -68,6 +68,12 @@ VARNISH_STORAGE="<%= scope.lookupvar('storage_type') %>,${VARNISH_STORAGE_FILE},
 #
 # # Default TTL used when the backend does not specify one
 VARNISH_TTL=<%= scope.lookupvar('varnish_ttl') %>
+
+#
+# # user and group
+VARNISH_USER="<%= scope.lookupvar('varnish_user') %>"
+VARNISH_GROUP="<%= scope.lookupvar('varnish_group') %>"
+
 #
 # # DAEMON_OPTS is used by the init script.  If you add or remove options, make
 # # sure you update this section, too.
@@ -77,6 +83,8 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -t ${VARNISH_TTL} \
              -S ${VARNISH_SECRET_FILE} \
              -s ${VARNISH_STORAGE} \
+             -u ${VARNISH_USER} \
+             -g ${VARNISH_GROUP} \
 <% if scope.lookupvar('varnish::params::version') == 4 -%>
              -p thread_pool_min=${VARNISH_MIN_THREADS} \
              -p thread_pool_max=${VARNISH_MAX_THREADS} \


### PR DESCRIPTION
- add `user` and `group` variables
- allow setting any of Varnish' `-p` options via `extra_options`

I have decided to add the `umask 022` bugfix at the very end of the template. This is unlikely (I think) to be accepted upstream, but since we needed it, I want to keep it. 
Our reference in puppet2: https://github.com/ByteInternet/puppet-platform/commit/de1992fb8867042b8a5273433cb58cf418f3c7bb

FYI, the followup on the post says "I'll add an "umask" statement to the init script for the next debian release of varnish." but

```
root@app1:/etc/init.d# grep umask varnish
root@app1:/etc/init.d#`
```
